### PR TITLE
Add read-write mode

### DIFF
--- a/libserialport/libserialport.scrbl
+++ b/libserialport/libserialport.scrbl
@@ -68,6 +68,14 @@ A high-level interface to port enumeration, access and configuration.
     (define-values (in out)
       (open-serial-port "/dev/ttyUSB0" #:baudrate 115200))
     (write-bytes #"x1AVx3\n" out)
+    (let loop ()
+      (define read-result (read-bytes-avail!* read-buffer port))
+      (cond [(or (eof-object? read-result)
+                 (and (number? read-result) (not (= read-result 0))))
+             (display (bytes->string/utf-8 (read-bytes read-result port)))
+             (display "")] ; flash output
+            [else (sleep 0.1)])
+      (loop))
   ]
 }
 

--- a/libserialport/main.rkt
+++ b/libserialport/main.rkt
@@ -20,7 +20,7 @@
     (-> Path-String Serial-Port))
 
   (sp_open
-    (-> Serial-Port (U 'read 'write) Void))
+    (-> Serial-Port Mode Void))
 
   (sp_set_baudrate
     (-> Serial-Port Positive-Integer Void))
@@ -57,6 +57,9 @@
 (define-type Flow-Control
   (U 'none 'xonxoff 'rtscts 'dtrdsr))
 
+(define-type Mode
+  (U 'read 'write 'read-write))
+
 
 (: serial-ports (-> (Listof Path-String)))
 (define (serial-ports)
@@ -70,18 +73,20 @@
         #:bits Positive-Integer
         #:parity Parity
         #:stopbits Natural
-        #:flowcontrol Flow-Control)
+        #:flowcontrol Flow-Control
+        #:mode Mode)
        (values Input-Port Output-Port)))
 (define (open-serial-port path
                           #:baudrate (baudrate 9600)
                           #:bits (bits 8)
                           #:parity (parity 'none)
                           #:stopbits (stopbits 1)
-                          #:flowcontrol (flowcontrol 'none))
+                          #:flowcontrol (flowcontrol 'none)
+                          #:mode (mode 'read-write))
   (security-guard-check-file 'open-serial-port path '(read write))
 
   (let ((port (sp_get_port_by_name path)))
-    (sp_open port 'write)
+    (sp_open port mode)
     (sp_set_baudrate port baudrate)
     (sp_set_bits port bits)
     (sp_set_parity port parity)

--- a/libserialport/private/ffi.rkt
+++ b/libserialport/private/ffi.rkt
@@ -70,7 +70,8 @@
 ;; Port access modes.
 (define _sp-mode
   (_enum '(read  = 1
-           write = 2)
+           write = 2
+           read-write = 3)
          _int))
 
 ;; Parity settings.


### PR DESCRIPTION
Thanks for sharing useful library.

`SP_MODE_READ_WRITE` is implemented as [`enum sp_mode`](https://sigrok.org/api/libserialport/unstable/a00004.html#a231bac8b80811a30abc0da2365ce3812) from libserial ver 0.1.1.
So, I enable it on your library.
Then, I succeeded in reading and writing on my PC.

Regards.
<hr>
My environment.

Name | Version
--- | ---
OS | ubuntu17.10
Racket | 6.12