### PR TITLE
use ffi/unsafe/port

### DIFF
--- a/libserialport/main.rkt
+++ b/libserialport/main.rkt
@@ -40,7 +40,7 @@
   (sp_get_port_handle
     (-> Serial-Port Integer))
 
-  (scheme_make_fd_output_port
+  (make-fd-output-port
     (-> Integer Symbol (values Input-Port Output-Port))))
 
 
@@ -95,7 +95,7 @@
 
     (let ((fd (sp_get_port_handle port))
           (name (path->port-name path)))
-      (scheme_make_fd_output_port fd name))))
+      (make-fd-output-port fd name))))
 
 
 (: path->port-name (-> Path-String Symbol))

--- a/libserialport/private/ffi.rkt
+++ b/libserialport/private/ffi.rkt
@@ -9,7 +9,8 @@
 (require racket/match
          racket/generator
          ffi/unsafe/define
-         ffi/unsafe/alloc)
+         ffi/unsafe/alloc
+         ffi/unsafe/port)
 
 (require misc1/throw)
 
@@ -262,14 +263,8 @@
            #:wrap (compose (convert bytes->string/utf-8)
                            (allocator sp_free_error_message)))
 
-(define-libc scheme_make_fd_output_port
-             (_fun (fd : _handle)
-                   (name : _racket)
-                   (regular? : _bool = #f)
-                   (text-mode? : _bool = #f)
-                   (read-too? : _bool = #t)
-                   --> _racket))
-
+(define (make-fd-output-port fd name)
+  (unsafe-file-descriptor->port fd name '(read write)))
 
 (define (in-serial-ports)
   (in-generator


### PR DESCRIPTION
CAUTION: I've never use `libserialport`, and don't know how to test the change made in this PR. I just noticed that #4 could potentially be fixed by using `ffi/unsafe/port` instead of using Racket BC-specific functions.

So, please test this change. If it works correctly, it would be a fix for #4. But if not, feel free to close it.

Fixes #4 